### PR TITLE
Fix authentication flow for MCP protocol compliance

### DIFF
--- a/AUTH_FIX.md
+++ b/AUTH_FIX.md
@@ -1,0 +1,70 @@
+# Authentication Fix for n8n MCP Client
+
+## Problem Identified
+
+Your logs showed:
+```
+MCP request received: initialize
+Error handling MCP request: Error: No API key provided
+```
+
+The MCP client (n8n) was making `initialize` and `notifications/initialized` requests **without** a Bearer token. This is actually **correct behavior** - these are handshake/discovery methods that shouldn't require authentication.
+
+## What I Fixed
+
+Changed authentication to be **method-specific**:
+
+### Methods that DON'T require authentication:
+- `initialize` - Server capability discovery
+- `notifications/initialized` - Handshake acknowledgment
+- `tools/list` - List available tools (discovery)
+
+### Methods that DO require authentication:
+- `tools/call` - Execute actual tool calls (needs API key)
+
+## Why This Is Correct
+
+According to MCP protocol:
+1. Client connects and calls `initialize` (no auth)
+2. Server responds with capabilities
+3. Client sends `notifications/initialized` (no auth)
+4. Client calls `tools/list` to discover tools (no auth)
+5. Client calls `tools/call` to execute (REQUIRES auth)
+
+Only the actual tool execution needs credentials because that's when we call the StatusGator API.
+
+## How to Apply
+
+```bash
+cd /docker/outage-monitor-mcp
+git pull
+docker-compose down
+docker-compose build --no-cache
+docker-compose up -d
+```
+
+## What You'll See
+
+After rebuild, your logs should show:
+```
+MCP request received: initialize
+(no auth error - success!)
+MCP request received: notifications/initialized
+(no auth error - success!)
+MCP request received: tools/list
+(no auth error - success!)
+MCP request received: tools/call
+Using bearer token from Authorization header
+(tool executes successfully!)
+```
+
+## Testing in n8n
+
+Your n8n MCP client should now:
+1. ✓ Connect successfully
+2. ✓ Discover the 5 available tools
+3. ✓ Execute tools using your bearer token
+
+Bearer token is only used when actually calling tools, not during the handshake.
+
+This is the standard MCP pattern and matches how other MCP servers work!

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -87,9 +87,6 @@ app.post('/mcp', async (req: Request, res: Response) => {
   console.log('MCP request received:', req.body.method);
 
   try {
-    // Get API key from bearer token or environment
-    const apiKey = getApiKey(req);
-
     // Set headers for streaming
     res.setHeader('Content-Type', 'application/json');
     res.setHeader('Cache-Control', 'no-cache');
@@ -99,6 +96,7 @@ app.post('/mcp', async (req: Request, res: Response) => {
 
     // Handle different MCP request types
     if (request.method === 'initialize') {
+      // Initialize doesn't require authentication
       const response = {
         jsonrpc: '2.0',
         id: request.id,
@@ -114,7 +112,11 @@ app.post('/mcp', async (req: Request, res: Response) => {
         },
       };
       res.json(response);
+    } else if (request.method === 'notifications/initialized') {
+      // Notification acknowledgment - no auth required, no response needed
+      res.status(200).end();
     } else if (request.method === 'tools/list') {
+      // Tools list doesn't require auth - just returns available tools
       // Get the tools from the server
       const tools = [
         {
@@ -187,8 +189,9 @@ app.post('/mcp', async (req: Request, res: Response) => {
       };
       res.json(response);
     } else if (request.method === 'tools/call') {
-      // Forward the tool call to the MCP server's handler
-      // Use the API key from bearer token or environment
+      // Tool calls require authentication - get API key from bearer token or environment
+      const apiKey = getApiKey(req);
+
       const toolName = request.params.name;
       const toolArgs = request.params.arguments;
 


### PR DESCRIPTION
Changed authentication to be method-specific to comply with MCP protocol standards and fix n8n MCP client connection issues.

Problem:
- Server was requiring authentication for ALL requests
- n8n MCP client sends initialize/notifications without bearer token
- This is correct MCP protocol behavior
- Resulted in "No API key provided" errors during handshake

Root Cause:
- getApiKey(req) was called at the start of every MCP request
- Discovery/handshake methods (initialize, notifications) don't need auth
- Only actual tool execution (tools/call) should require credentials

Solution:
Changed authentication to be method-specific:

Methods WITHOUT authentication (discovery/handshake):
1. initialize - Returns server capabilities
   - Used by client to discover what server can do
   - No sensitive data, just metadata

2. notifications/initialized - Handshake acknowledgment
   - Client tells server it received capabilities
   - Protocol-level notification, no auth needed

3. tools/list - Returns list of available tools
   - Discovery method to see what tools are available
   - Doesn't execute anything, just returns schemas
   - No API calls made

Methods WITH authentication (execution):
1. tools/call - Execute actual tool
   - getApiKey(req) called here
   - Makes real API calls to StatusGator
   - Requires credentials to access external API

Changes to src/http-server.ts:
- Removed getApiKey() from top of /mcp handler
- Added explicit handling for notifications/initialized
- Moved getApiKey() call to only tools/call block
- Added comments explaining auth requirements

Benefits:
- Complies with MCP protocol standard
- Matches behavior of other MCP servers
- Allows n8n to complete handshake successfully
- Still requires auth for actual tool execution
- Better security - auth only where needed

Expected Flow:
1. Client: initialize (no auth) → Server: returns capabilities
2. Client: notifications/initialized (no auth) → Server: acknowledges
3. Client: tools/list (no auth) → Server: returns 5 tools
4. Client: tools/call (WITH auth) → Server: executes with bearer token

Documentation:
- Created AUTH_FIX.md explaining the issue and fix
- Documents proper MCP authentication flow
- Provides testing steps for n8n users

This is standard MCP protocol behavior and matches reference implementations from other MCP servers.

Generated with [Claude Code](https://claude.com/claude-code)