### PR TITLE
Add historical data and uptime analytics tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,110 @@ Search for a service by name in the StatusGator database.
 }
 ```
 
+### 6. `get_historical_incidents`
+
+Get historical incidents for a service within a specific date range. Perfect for analyzing past outages and incident patterns.
+
+**Parameters:**
+- `service` (required): Service name
+- `start_date` (optional): Start date in ISO format (e.g., "2025-01-01T00:00:00Z")
+- `end_date` (optional): End date in ISO format (e.g., "2025-01-31T23:59:59Z")
+- `status` (optional): Filter by status (e.g., "resolved", "investigating")
+
+**Example:**
+```json
+{
+  "service": "aws",
+  "start_date": "2025-01-01T00:00:00Z",
+  "end_date": "2025-01-31T23:59:59Z"
+}
+```
+
+**Response:**
+```json
+{
+  "service": "aws",
+  "start_date": "2025-01-01T00:00:00Z",
+  "end_date": "2025-01-31T23:59:59Z",
+  "total_incidents": 3,
+  "incidents": [
+    {
+      "id": "incident-456",
+      "service_name": "Amazon Web Services",
+      "title": "EC2 connectivity issues",
+      "created_at": "2025-01-15T10:30:00Z",
+      "resolved_at": "2025-01-15T12:45:00Z",
+      "status": "resolved"
+    }
+  ]
+}
+```
+
+### 7. `get_service_uptime`
+
+Calculate uptime statistics for a service over a specific period. Returns uptime percentage and total downtime.
+
+**Parameters:**
+- `service` (required): Service name
+- `start_date` (required): Start date in ISO format
+- `end_date` (required): End date in ISO format
+
+**Example:**
+```json
+{
+  "service": "verizon",
+  "start_date": "2025-01-01T00:00:00Z",
+  "end_date": "2025-01-31T23:59:59Z"
+}
+```
+
+**Response:**
+```json
+{
+  "service_id": "verizon",
+  "service_name": "Verizon",
+  "period_start": "2025-01-01T00:00:00Z",
+  "period_end": "2025-01-31T23:59:59Z",
+  "total_incidents": 2,
+  "total_downtime_minutes": 180,
+  "uptime_percentage": 99.75,
+  "incidents": [...]
+}
+```
+
+### 8. `get_multi_service_history`
+
+Get incident history for multiple services at once. Useful for comparing outages across carriers or cloud providers.
+
+**Parameters:**
+- `services` (required): Array of service names
+- `start_date` (optional): Start date in ISO format
+- `end_date` (optional): End date in ISO format
+
+**Example:**
+```json
+{
+  "services": ["att", "verizon", "t-mobile"],
+  "start_date": "2025-01-01T00:00:00Z",
+  "end_date": "2025-01-31T23:59:59Z"
+}
+```
+
+**Response:**
+```json
+{
+  "services": ["att", "verizon", "t-mobile"],
+  "start_date": "2025-01-01T00:00:00Z",
+  "end_date": "2025-01-31T23:59:59Z",
+  "total_incidents": 5,
+  "history": {
+    "att": [...incidents...],
+    "verizon": [...incidents...],
+    "t-mobile": [...incidents...]
+  }
+}
+```
+
 ## Supported Services
 
 The server monitors these services:


### PR DESCRIPTION
Implemented three new MCP tools for accessing historical incident data and calculating uptime statistics from the StatusGator API.

New Tools:

1. get_historical_incidents
   - Retrieve past incidents for any service within a date range
   - Optional filters: start_date, end_date, status
   - Returns sorted list of historical incidents
   - Use case: Analyze outage patterns, compliance reporting

2. get_service_uptime
   - Calculate uptime percentage over a specific period
   - Returns total incidents, downtime minutes, uptime %
   - Includes full incident list for the period
   - Use case: SLA tracking, reliability analysis

3. get_multi_service_history
   - Compare incident history across multiple services
   - Supports date range filtering
   - Returns aggregated stats and per-service breakdowns
   - Use case: Carrier comparisons, multi-cloud analysis

Implementation Details:

StatusGator Client (src/statusgator.ts):
- Added HistoricalQuery and UptimeStats interfaces
- getHistoricalIncidents(): Fetches and filters incidents by date/status
- getServiceUptime(): Calculates uptime metrics with downtime calculation
- getMultiServiceHistory(): Parallel fetching for multiple services
- getIncidentDetails(): Retrieve specific incident by ID

HTTP Server (src/http-server.ts):
- Added 3 new tool definitions with comprehensive schemas
- Implemented tool handlers with parameter validation
- Date range handling with ISO 8601 format
- Array parameter support for multi-service queries
- Updated tool list to show 8 total tools

Documentation (README.md):
- Added detailed examples for each new tool
- Sample requests and responses with realistic data
- Parameter descriptions and requirements
- Use case explanations

Features:
- Historical incident analysis
- Uptime/downtime calculations
- Multi-service comparisons
- Flexible date range queries
- Status filtering (resolved, investigating, etc.)
- Sorted results (newest first)

Example Use Cases:
- "Show me all AWS outages in January 2025"
- "What was Verizon's uptime last month?"
- "Compare AT&T vs T-Mobile vs Verizon outages"
- "Calculate Azure uptime for Q4 2024"

The MCP server now provides 8 tools total:
1. check_outage (current status)
2. check_all_outages (current status)
3. get_service_status (current status)
4. get_all_incidents (current incidents)
5. search_service (discovery)
6. get_historical_incidents (NEW - historical data)
7. get_service_uptime (NEW - analytics)
8. get_multi_service_history (NEW - comparisons)

This enables comprehensive outage monitoring with both real-time and historical capabilities for carriers and cloud services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)